### PR TITLE
fix(solana): dynamically resolve source USDC addresses from Bridge Kit

### DIFF
--- a/lib/bridgeKit.ts
+++ b/lib/bridgeKit.ts
@@ -579,3 +579,17 @@ export const getCctpConfirmationsUniversal = (
   return getCctpConfirmations(chainId, env);
 };
 
+/**
+ * Get USDC address for an EVM chain by its CCTP domain.
+ * Used for Solana mint token pair PDA derivation.
+ * Dynamically pulls from Bridge Kit so new chains are automatically supported.
+ */
+export const getUsdcAddressByDomain = (
+  domain: number,
+  env: BridgeEnvironment = DEFAULT_ENV
+): string | null => {
+  const chains = getSupportedEvmChains(env);
+  const chain = chains.find((c) => c.cctp?.domain === domain);
+  return chain?.usdcAddress ?? null;
+};
+


### PR DESCRIPTION
## Summary
- Fixes "Unknown source USDC address for domain 13" error when bridging from Sonic → Solana
- Replaces static USDC address mappings with dynamic lookup from Bridge Kit SDK
- New chains added to Bridge Kit will be automatically supported without code changes

## Changes
- Add `getUsdcAddressByDomain()` utility to `lib/bridgeKit.ts`
- Update `lib/cctp/solana/mint.ts` to use dynamic resolution
- Remove ~27 lines of hardcoded USDC address mappings

## Test plan
- [ ] Verify Sonic → Solana bridge claim works
- [ ] Verify existing EVM → Solana routes still work (Arbitrum, Base, etc.)
- [ ] Run lint: `bun run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)