### PR TITLE
fix(cctp): handle expired attestations with re-attestation support

### DIFF
--- a/.claude/skills/anchor-program-integration/SKILL.md
+++ b/.claude/skills/anchor-program-integration/SKILL.md
@@ -1,0 +1,77 @@
+# Anchor Program Integration
+
+Use this skill when building raw Solana instructions that interact with Anchor programs, especially when bypassing Anchor's method builders.
+
+## Key Concept: What Anchor Method Builders Do
+
+When you use Anchor's method builder pattern:
+```typescript
+await program.methods['myInstruction'](params)
+  .accounts({ ... })
+  .remainingAccounts([...])
+  .instruction();
+```
+
+Anchor automatically:
+1. Serializes instruction data with the correct discriminator
+2. Orders accounts according to the IDL
+3. **Appends macro-injected accounts** (like `#[event_cpi]`)
+
+## #[event_cpi] Macro
+
+The `#[event_cpi]` macro is used for emitting events via CPI (Cross-Program Invocation).
+
+### What It Does
+
+When an instruction has `#[event_cpi]`, Anchor:
+1. Expects two additional accounts at the END of the instruction accounts (but BEFORE remaining_accounts when using method builder)
+2. These accounts are: `event_authority` PDA and `program` ID
+
+### Account Positions
+
+**With Anchor method builder**: Accounts are auto-appended
+**Without method builder (raw instruction)**: You must add them manually at positions [N] and [N+1] where N is the number of main instruction accounts
+
+```typescript
+// For an instruction with 7 main accounts:
+// [0-6] = main accounts
+// [7]   = event_authority (PDA with seed "__event_authority")
+// [8]   = program ID
+// [9+]  = remaining_accounts
+```
+
+### Deriving event_authority
+
+```typescript
+const [eventAuthorityPda] = PublicKey.findProgramAddressSync(
+  [Buffer.from("__event_authority")],
+  PROGRAM_ID  // The program that has #[event_cpi]
+);
+```
+
+## Instruction Data Serialization
+
+Anchor instructions start with an 8-byte discriminator:
+
+```typescript
+// Discriminator = SHA256("global:instruction_name").slice(0, 8)
+const discriminator = crypto
+  .createHash("sha256")
+  .update("global:receive_message")
+  .digest()
+  .slice(0, 8);
+```
+
+For Borsh serialization of Vec<u8> parameters:
+```typescript
+// Format: [4-byte length (u32 LE)][data bytes]
+buffer.writeUInt32LE(data.length, offset);
+data.copy(buffer, offset + 4);
+```
+
+## Common Pitfalls
+
+1. **Wrong event_authority position**: Must be immediately after main accounts, not at end of all accounts
+2. **Wrong program for PDA derivation**: Each program has its OWN event_authority PDA
+3. **Missing discriminator**: Raw instructions need the 8-byte discriminator prefix
+4. **Wrong Borsh encoding**: Vec<u8> needs length prefix, not raw bytes

--- a/.claude/skills/solana-cctp-v2/SKILL.md
+++ b/.claude/skills/solana-cctp-v2/SKILL.md
@@ -1,0 +1,81 @@
+# Solana CCTP v2 Integration
+
+Use this skill when working with Circle's Cross-Chain Transfer Protocol v2 on Solana, including `receiveMessage` (mint) and `depositForBurn` operations.
+
+## Program IDs
+
+```typescript
+// Same for mainnet and devnet
+const MESSAGE_TRANSMITTER_PROGRAM_ID = "CCTPV2Sm4AdWt5296sk4P66VBZ7bEhcARwFaaS9YPbeC";
+const TOKEN_MESSENGER_PROGRAM_ID = "CCTPV2vPZJS2u2BBsUoscuikbYjnpFmbFsvVuJdgUMQe";
+```
+
+## PDA Derivation Rules
+
+**Critical**: Each PDA must be derived from the CORRECT program ID.
+
+| PDA | Seed | Program ID |
+|-----|------|------------|
+| `tokenMessengerPda` | `"token_messenger"` | TOKEN_MESSENGER |
+| `messageTransmitterPda` | `"message_transmitter"` | MESSAGE_TRANSMITTER |
+| `tokenMinterPda` | `"token_minter"` | TOKEN_MESSENGER |
+| `localTokenPda` | `["local_token", mint]` | TOKEN_MESSENGER |
+| `remoteTokenMessengerPda` | `["remote_token_messenger", domain]` | TOKEN_MESSENGER |
+| `tokenPairPda` | `["token_pair", domain, sourceUsdc]` | TOKEN_MESSENGER |
+| `custodyPda` | `["custody", mint]` | TOKEN_MESSENGER |
+| `messageTransmitterAuthorityPda` | `["message_transmitter_authority", TOKEN_MESSENGER_ID]` | MESSAGE_TRANSMITTER |
+| `usedNoncePda` | `["used_nonce", nonce]` | MESSAGE_TRANSMITTER |
+| `messageTransmitterEventAuthorityPda` | `"__event_authority"` | MESSAGE_TRANSMITTER |
+| `tokenMessengerEventAuthorityPda` | `"__event_authority"` | TOKEN_MESSENGER |
+
+## receiveMessage Account Order (20 accounts)
+
+When building `receiveMessage` instruction manually (bypassing Anchor method builder):
+
+```typescript
+const keys = [
+  // === Core MessageTransmitter accounts [0-6] ===
+  { pubkey: user, isSigner: true, isWritable: true },                    // [0] payer
+  { pubkey: user, isSigner: true, isWritable: false },                   // [1] caller
+  { pubkey: messageTransmitterAuthorityPda, ... },                       // [2] authority_pda
+  { pubkey: messageTransmitterPda, ... },                                // [3] message_transmitter
+  { pubkey: usedNoncePda, isWritable: true },                            // [4] used_nonces
+  { pubkey: TOKEN_MESSENGER_PROGRAM_ID, ... },                           // [5] receiver
+  { pubkey: SystemProgram.programId, ... },                              // [6] system_program
+
+  // === MessageTransmitter event_cpi accounts [7-8] ===
+  // CRITICAL: Must be immediately after main accounts!
+  { pubkey: messageTransmitterEventAuthorityPda, ... },                  // [7] MT event_authority
+  { pubkey: MESSAGE_TRANSMITTER_PROGRAM_ID, ... },                       // [8] MT program
+
+  // === Remaining accounts for CPI to TokenMessenger [9-19] ===
+  { pubkey: tokenMessengerPda, ... },                                    // [9]
+  { pubkey: remoteTokenMessengerPda, ... },                              // [10]
+  { pubkey: tokenMinterPda, isWritable: true },                          // [11]
+  { pubkey: localTokenPda, isWritable: true },                           // [12]
+  { pubkey: tokenPairPda, ... },                                         // [13]
+  { pubkey: feeRecipientAta, isWritable: true },                         // [14]
+  { pubkey: userUsdcAta, isWritable: true },                             // [15]
+  { pubkey: custodyPda, isWritable: true },                              // [16]
+  { pubkey: TOKEN_PROGRAM_ID, ... },                                     // [17]
+  // TokenMessenger event_cpi accounts
+  { pubkey: tokenMessengerEventAuthorityPda, ... },                      // [18] TM event_authority
+  { pubkey: TOKEN_MESSENGER_PROGRAM_ID, ... },                           // [19] TM program
+];
+```
+
+## Common Errors
+
+### ConstraintSeeds Error 2006
+
+**Symptom**: `AnchorError caused by account: event_authority. Error Code: ConstraintSeeds`
+
+**Causes**:
+1. `event_authority` derived from wrong program ID
+2. `event_cpi` accounts at wrong positions (must be [7-8], not at end)
+
+**Fix**: Verify PDA derivation matches table above and accounts are in exact order shown.
+
+## Reference Implementation
+
+See `@circle-fin/adapter-solana` npm package for official implementation. Key file: `buildInstructions` function in the adapter.

--- a/.claude/skills/solana-transactions/SKILL.md
+++ b/.claude/skills/solana-transactions/SKILL.md
@@ -1,0 +1,112 @@
+# Solana Transactions and Address Lookup Tables
+
+Use this skill when working with Solana transaction size limits, Address Lookup Tables (ALTs), and VersionedTransactions.
+
+## Transaction Size Limit
+
+Solana transactions have a **hard limit of 1232 bytes**. This includes:
+- Signatures (64 bytes each)
+- Message header (3 bytes)
+- Account addresses (32 bytes each, unless using ALT)
+- Instructions (variable)
+
+## When ALT is Needed
+
+Calculate transaction size:
+- Each account = 32 bytes (without ALT) or 1 byte (with ALT)
+- Large instructions (like CCTP messages ~400+ bytes) leave less room for accounts
+
+**Example**: CCTP receiveMessage with 20 accounts:
+- Without ALT: ~1474 bytes (EXCEEDS LIMIT)
+- With ALT: ~916 bytes (OK)
+
+## Address Lookup Tables (ALT)
+
+ALTs store frequently-used addresses on-chain. Transactions reference them by 1-byte index instead of 32-byte address.
+
+### Creating an ALT
+
+```typescript
+import { AddressLookupTableProgram, Connection, Keypair } from "@solana/web3.js";
+
+// 1. Create the ALT
+const [createIx, altAddress] = AddressLookupTableProgram.createLookupTable({
+  authority: payer.publicKey,
+  payer: payer.publicKey,
+  recentSlot: await connection.getSlot(),
+});
+
+// 2. Extend with addresses
+const extendIx = AddressLookupTableProgram.extendLookupTable({
+  payer: payer.publicKey,
+  authority: payer.publicKey,
+  lookupTable: altAddress,
+  addresses: [address1, address2, ...],  // Max ~30 per instruction
+});
+
+// 3. Wait for activation (~1 slot)
+```
+
+### Using an ALT in Transactions
+
+```typescript
+import { TransactionMessage, VersionedTransaction } from "@solana/web3.js";
+
+// Fetch ALT from chain
+const altAccountInfo = await connection.getAddressLookupTable(altAddress);
+const addressLookupTable = altAccountInfo.value;
+
+// Build VersionedTransaction
+const messageV0 = new TransactionMessage({
+  payerKey: user,
+  recentBlockhash: blockhash,
+  instructions,
+}).compileToV0Message([addressLookupTable]);
+
+const versionedTx = new VersionedTransaction(messageV0);
+```
+
+## Legacy vs Versioned Transactions
+
+| Feature | Legacy Transaction | VersionedTransaction (v0) |
+|---------|-------------------|---------------------------|
+| ALT support | No | Yes |
+| Max accounts | ~35 (size limited) | 256 (with ALT) |
+| Wallet support | Universal | Most modern wallets |
+
+### Type Guard
+
+```typescript
+function isVersionedTransaction(
+  tx: Transaction | VersionedTransaction
+): tx is VersionedTransaction {
+  return "version" in tx;
+}
+```
+
+## ALT Best Practices
+
+1. **Include static addresses only** - Program IDs, PDAs that don't change
+2. **Don't include dynamic addresses** - User wallets, ATAs vary per transaction
+3. **Validate before use** - Check ALT exists and has expected address count
+4. **Fallback to legacy** - If ALT unavailable, try legacy (may fail for large txs)
+
+```typescript
+async function fetchAlt(connection, altAddress) {
+  const info = await connection.getAddressLookupTable(altAddress);
+  if (!info.value || info.value.state.addresses.length < expectedCount) {
+    return null; // Fallback to legacy
+  }
+  return info.value;
+}
+```
+
+## Sending Transactions
+
+```typescript
+// Works for both legacy and versioned
+const signature = await connection.sendRawTransaction(
+  signedTransaction.serialize(),
+  { skipPreflight: false, preflightCommitment: "confirmed" }
+);
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,3 +136,23 @@ isValidTxHash(value)       // Universal tx hash validation
 - Path aliases use `@/*` pointing to project root
 - Run `bun run lint` after changes (build not required for every change)
 - Solana burn returns immediately after send (no confirmation wait to avoid WebSocket hangs)
+
+---
+
+## Solana Program Integration Guidelines
+
+When implementing Solana program interactions:
+
+1. **Research PDA derivation first** — Verify which program ID each PDA should be derived from before implementation
+2. **Check account ordering** — Anchor macros like `#[event_cpi]` expect accounts at specific positions (e.g., [7-8] for event_cpi, not at the end)
+3. **Compare against official SDK** — Find and read the official adapter implementation (e.g., `@circle-fin/adapter-solana`) before building custom instructions
+4. **Test with simulation first** — Use `simulateTransaction` to catch account mismatches before signing
+
+### Debugging Solana Transaction Failures
+
+For `ConstraintSeeds` or similar account errors:
+
+1. **Map ALL accounts first** — List every account with its expected program derivation source
+2. **Compare against official implementation** — Match account order exactly against Circle's adapter
+3. **Verify PDAs independently** — Compute each PDA locally and verify against on-chain data
+4. **Don't iterate blindly** — Understand the full instruction structure before making changes

--- a/components/bridging-state/bridging-state.tsx
+++ b/components/bridging-state/bridging-state.tsx
@@ -176,6 +176,10 @@ export function BridgingState({
     attestationReady,
     checking: isCheckingMint,
     setAlreadyMinted,
+    setMessageExpired,
+    messageExpired,
+    requestReattest,
+    isReattesting,
   } = useMintPolling({
     burnTxHash,
     sourceChainId,
@@ -220,6 +224,10 @@ export function BridgingState({
     setAlreadyMinted(true);
   }, [setAlreadyMinted]);
 
+  const handleMessageExpired = useCallback((nonce: string) => {
+    setMessageExpired(nonce);
+  }, [setMessageExpired]);
+
   const { handleClaim, isClaiming } = useClaimHandler({
     destinationChainId,
     sourceChainId,
@@ -228,6 +236,7 @@ export function BridgingState({
     onDestinationChain,
     onSuccess: handleClaimSuccess,
     onAlreadyMinted: handleAlreadyMinted,
+    onMessageExpired: handleMessageExpired,
   });
 
   // Track burn/mint completion timestamps
@@ -445,6 +454,9 @@ export function BridgingState({
             isCheckingMint={isCheckingMint}
             isSwitchingChain={isSwitchingChain}
             onClaim={handleClaim}
+            messageExpired={messageExpired}
+            onReattest={requestReattest}
+            isReattesting={isReattesting}
           />
 
           <BridgeInfo

--- a/components/bridging-state/claim-section.tsx
+++ b/components/bridging-state/claim-section.tsx
@@ -11,7 +11,32 @@ export function ClaimSection({
   isCheckingMint,
   isSwitchingChain,
   onClaim,
+  messageExpired,
+  onReattest,
+  isReattesting,
 }: ClaimSectionProps) {
+  // Show re-attest button if message has expired
+  if (messageExpired && onReattest) {
+    return (
+      <div className="flex flex-col gap-2">
+        <Button
+          className="w-full bg-amber-600 hover:bg-amber-700 text-white"
+          disabled={isReattesting}
+          onClick={onReattest}
+        >
+          {isReattesting ? (
+            <span className="flex items-center justify-center gap-2">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Requesting new attestation...
+            </span>
+          ) : (
+            "Attestation Expired. Request a new Attestation."
+          )}
+        </Button>
+      </div>
+    );
+  }
+
   if (!showClaimButton) return null;
 
   return (

--- a/components/bridging-state/types.ts
+++ b/components/bridging-state/types.ts
@@ -45,6 +45,12 @@ export interface ClaimSectionProps {
   isCheckingMint: boolean;
   isSwitchingChain: boolean;
   onClaim: () => void;
+  /** True if the message attestation has expired and needs re-signing */
+  messageExpired?: boolean;
+  /** Callback to request re-attestation */
+  onReattest?: () => void;
+  /** True if re-attestation is in progress */
+  isReattesting?: boolean;
 }
 
 export interface BridgeInfoProps {

--- a/lib/cctp/hooks/useMint.ts
+++ b/lib/cctp/hooks/useMint.ts
@@ -177,6 +177,16 @@ export function useMint() {
       }
 
       if (!simResult.canMint) {
+        // Check if message has expired - needs re-attestation
+        if (simResult.messageExpired) {
+          return {
+            success: false,
+            messageExpired: true,
+            nonce: attestationData.nonce,
+            error: "Message expired - please request re-attestation",
+          };
+        }
+
         return {
           success: false,
           error: simResult.error || "Simulation failed - mint may not be ready",

--- a/lib/cctp/types.ts
+++ b/lib/cctp/types.ts
@@ -145,6 +145,10 @@ export interface MintResult {
   error?: string;
   /** True if mint was already executed (nonce used) */
   alreadyMinted?: boolean;
+  /** True if the attestation has expired and needs re-signing */
+  messageExpired?: boolean;
+  /** The nonce for re-attestation (when messageExpired is true) */
+  nonce?: string;
 }
 
 // =============================================================================

--- a/lib/contracts.ts
+++ b/lib/contracts.ts
@@ -185,11 +185,13 @@ export function isTestnetChainUniversal(
  * This matches the CCTP contract's _hashSourceAndNonce implementation.
  */
 export function hashSourceAndNonce(sourceDomain: number, nonce: string): `0x${string}` {
-  // CCTP uses keccak256(abi.encodePacked(uint32 sourceDomain, uint64 nonce))
+  // CCTP v2 uses keccak256(abi.encodePacked(uint32 sourceDomain, bytes32 nonce))
+  // Nonces are 32-byte values, not 64-bit integers
+  const nonceHex = nonce.startsWith("0x") ? nonce : `0x${nonce}`;
   return keccak256(
     encodePacked(
-      ["uint32", "uint64"],
-      [sourceDomain, BigInt(nonce)]
+      ["uint32", "bytes32"],
+      [sourceDomain, nonceHex as `0x${string}`]
     )
   );
 }

--- a/lib/hooks/useClaimHandler.ts
+++ b/lib/hooks/useClaimHandler.ts
@@ -16,6 +16,8 @@ interface UseClaimHandlerParams {
   onDestinationChain: boolean;
   onSuccess: (updatedSteps: BridgeResult["steps"]) => void;
   onAlreadyMinted?: () => void;
+  /** Called when the message has expired and needs re-attestation */
+  onMessageExpired?: (nonce: string) => void;
 }
 
 interface UseClaimHandlerResult {
@@ -35,6 +37,7 @@ export function useClaimHandler({
   onDestinationChain,
   onSuccess,
   onAlreadyMinted,
+  onMessageExpired,
 }: UseClaimHandlerParams): UseClaimHandlerResult {
   const { switchChain } = useSwitchChain();
   const solanaWallet = useWallet();
@@ -154,6 +157,14 @@ export function useClaimHandler({
         if (result.alreadyMinted) {
           onAlreadyMinted?.();
         }
+      } else if (result.messageExpired && result.nonce) {
+        // Message expired - trigger re-attestation flow
+        onMessageExpired?.(result.nonce);
+        toast({
+          title: "Attestation expired",
+          description: "Please request re-attestation to continue.",
+          variant: "destructive",
+        });
       } else {
         toast({
           title: "Claim failed",
@@ -173,6 +184,7 @@ export function useClaimHandler({
     executeMint,
     onSuccess,
     onAlreadyMinted,
+    onMessageExpired,
     toast,
   ]);
 


### PR DESCRIPTION
## Summary
- Fix nonce overflow error by normalizing decimal nonces from Iris API to hex bytes32
- Add POST /v2/reattest endpoint support for expired CCTP v2 messages
- Detect "Message expired" errors in mint simulation and surface to UI
- Add re-attestation button when attestation expires (24-hour CCTP limit)
- Stop polling when message expired, resume after re-attestation requested

## Test plan
- [ ] Test EVM→EVM bridge with fresh transaction
- [ ] Test claiming an expired attestation shows re-attest button
- [ ] Test re-attestation request triggers polling to resume

🤖 Generated with [Claude Code](https://claude.com/claude-code)